### PR TITLE
bump target .net framework to 6.0 for both projects

### DIFF
--- a/Tailspin.SpaceGame.Web.Tests/Tailspin.SpaceGame.Web.Tests.csproj
+++ b/Tailspin.SpaceGame.Web.Tests/Tailspin.SpaceGame.Web.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <ProjectGuid>{773BA444-0D67-4F37-8762-17E108CCD5F5}</ProjectGuid>
   </PropertyGroup>

--- a/Tailspin.SpaceGame.Web/Tailspin.SpaceGame.Web.csproj
+++ b/Tailspin.SpaceGame.Web/Tailspin.SpaceGame.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ProjectGuid>{A0C4E31E-AC75-4F39-9F59-0AA19D9B8F46}</ProjectGuid>
   </PropertyGroup>
 


### PR DESCRIPTION
@shuerta0193  @mpieler1 
Please merge this PR - the .net5.0 framework causes the pipeline to fail.  I've confirmed that .net6.0 allows the pipeline to succeed.

